### PR TITLE
Restore support for more than 1000 partitions with partitioned copy job

### DIFF
--- a/resources/lakefed_ingest_controller.yml
+++ b/resources/lakefed_ingest_controller.yml
@@ -40,11 +40,12 @@ resources:
             task:
               task_key: run_copy_partitioned_job
               run_job_task:
-                job_id: ${resources.jobs.lakefed_ingest_copy_partitioned.id}
+                job_id: ${resources.jobs.lakefed_ingest_copy_partitioned_lvl1.id}
                 job_parameters:
                   task_id: "{{input.id}}"
       tags:
-        workload: lakefed_ingest
+        business_unit: ""
+        project: lakefed_ingest
       queue:
         enabled: false
       parameters:

--- a/resources/lakefed_ingest_copy.yml
+++ b/resources/lakefed_ingest_copy.yml
@@ -92,7 +92,8 @@ resources:
             parameters:
               watermark_col_end_value: "{{tasks.get_new_watermark.output.first_row.watermark}}"   
       tags:
-        workload: lakefed_ingest
+        business_unit: ""
+        project: lakefed_ingest
       queue:
         enabled: false
       parameters:

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -1,7 +1,7 @@
 resources:
   jobs:
-    lakefed_ingest_copy_partitioned:
-      name: "lakefed_ingest_copy_partitioned"
+    lakefed_ingest_copy_partitioned_lvl1:
+      name: "lakefed_ingest_copy_partitioned_lvl1"
       description: "Performs a partitioned copy using parameters returned from get_task"
       tasks:
         - task_key: get_task
@@ -26,52 +26,49 @@ resources:
               sink_cluster_cols: "{{tasks.get_task.output.first_row.sink_cluster_cols}}"
             source: WORKSPACE
             warehouse_id: ${var.warehouse_id}
-        - task_key: get_partitions
-          description: "Gets partitions Sets taskValues used by foreach_partition"
+        - task_key: generate_partitions
           depends_on:
             - task_key: create_sink_table
           notebook_task:
-            notebook_path: ../src/lakefed_ingest/get_partitions.ipynb
+            notebook_path: /Workspace/Users/chris.koester@databricks.com/lakefed_ingest/src/lakefed_ingest/generate_partitions
             base_parameters:
-              src_type: "{{tasks.get_task.output.first_row.src_type}}"
+              partition_col: "{{tasks.get_task.output.first_row.partition_col}}"
+              partition_size_mb: "{{tasks.get_task.output.first_row.partition_size_mb}}"
               src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
               src_schema: "{{tasks.get_task.output.first_row.src_schema}}"
               src_table: "{{tasks.get_task.output.first_row.src_table}}"
-              partition_col: "{{tasks.get_task.output.first_row.partition_col}}"
-              partition_size_mb: "{{tasks.get_task.output.first_row.partition_size_mb}}"
+              src_type: "{{tasks.get_task.output.first_row.src_type}}"
               tgt_catalog: "{{tasks.get_task.output.first_row.sink_catalog}}"
               tgt_schema: "{{tasks.get_task.output.first_row.sink_schema}}"
               tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
             source: WORKSPACE
           existing_cluster_id: ${var.cluster_id}
           libraries:
-            - whl: ../dist/*.whl
-        - task_key: foreach_partition
-          description: "Iterates id_list set in get_partitions task"
+            - whl: /Workspace/Users/chris.koester@databricks.com/.bundle/lakefed_ingest/dev/artifacts/.internal/lakefed_ingest-0.0.1+20250903.145732-py3-none-any.whl
+          description: Gets partitions Sets taskValues used by foreach_partition
+        - task_key: foreach_batch
           depends_on:
-            - task_key: get_partitions
+            - task_key: generate_partitions
           for_each_task:
-            inputs: "{{tasks.get_partitions.values.id_list}}"
-            concurrency: ${var.concurrency}
+            inputs: "{{tasks.generate_partitions.values.batch_id_list}}"
+            concurrency: 1
             task:
-              task_key: copy_data
-              description: "Copies data based on provided parameters"
-              notebook_task:
-                notebook_path: ../src/lakefed_ingest/copy_data_partitioned.ipynb
-                source: WORKSPACE
-                warehouse_id: ${var.warehouse_id}
-                base_parameters:
-                  src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
+              task_key: copy_batch
+              run_job_task:
+                job_id: ${resources.jobs.lakefed_ingest_copy_partitioned_lvl2.id}
+                job_parameters:
                   src_schema: "{{tasks.get_task.output.first_row.src_schema}}"
+                  src_catalog: "{{tasks.get_task.output.first_row.src_catalog}}"
                   src_table: "{{tasks.get_task.output.first_row.src_table}}"
                   tgt_catalog: "{{tasks.get_task.output.first_row.sink_catalog}}"
                   tgt_schema: "{{tasks.get_task.output.first_row.sink_schema}}"
                   tgt_table: "{{tasks.get_task.output.first_row.sink_table}}"
-                  partition_id: "{{input}}"
-              max_retries: 2
-              min_retry_interval_millis: 0
+                  batch_id: "{{input}}"
+              description: Copies data based on provided parameters
+          description: Iterates id_list set in get_partitions task
       tags:
-        workload: lakefed_ingest
+        business_unit: ""
+        project: lakefed_ingest
       queue:
         enabled: false
       parameters:

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -30,7 +30,7 @@ resources:
           depends_on:
             - task_key: create_sink_table
           notebook_task:
-            notebook_path: /Workspace/Users/chris.koester@databricks.com/lakefed_ingest/src/lakefed_ingest/generate_partitions
+            notebook_path: ../src/lakefed_ingest/generate_partitions
             base_parameters:
               partition_col: "{{tasks.get_task.output.first_row.partition_col}}"
               partition_size_mb: "{{tasks.get_task.output.first_row.partition_size_mb}}"
@@ -44,7 +44,7 @@ resources:
             source: WORKSPACE
           existing_cluster_id: ${var.cluster_id}
           libraries:
-            - whl: /Workspace/Users/chris.koester@databricks.com/.bundle/lakefed_ingest/dev/artifacts/.internal/lakefed_ingest-0.0.1+20250903.145732-py3-none-any.whl
+            - whl: ../dist/*.whl
           description: Gets partitions Sets taskValues used by foreach_partition
         - task_key: foreach_batch
           depends_on:

--- a/resources/lakefed_ingest_copy_partitioned_lvl1.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl1.yml
@@ -30,7 +30,7 @@ resources:
           depends_on:
             - task_key: create_sink_table
           notebook_task:
-            notebook_path: ../src/lakefed_ingest/generate_partitions
+            notebook_path: ../src/lakefed_ingest/generate_partitions.ipynb
             base_parameters:
               partition_col: "{{tasks.get_task.output.first_row.partition_col}}"
               partition_size_mb: "{{tasks.get_task.output.first_row.partition_size_mb}}"

--- a/resources/lakefed_ingest_copy_partitioned_lvl2.yml
+++ b/resources/lakefed_ingest_copy_partitioned_lvl2.yml
@@ -1,0 +1,51 @@
+resources:
+  jobs:
+    lakefed_ingest_copy_partitioned_lvl2:
+      name: lakefed_ingest_copy_partitioned_lvl2
+      description: Copies a batch of partitioned copy tasks. This job is called from lakefed_ingest_copy_partitioned_lvl1 and not meant to be run directly.
+      tasks:
+        - task_key: get_partitions
+          sql_task:
+            file:
+              path: ../src/lakefed_ingest/get_partition_ids.sql
+              source: WORKSPACE
+            warehouse_id: ${var.warehouse_id}
+          description: Gets partitions Sets taskValues used by foreach_partition
+        - task_key: foreach_partition
+          depends_on:
+            - task_key: get_partitions
+          for_each_task:
+            inputs: "{{tasks.get_partitions.output.rows}}"
+            concurrency: 32
+            task:
+              task_key: copy_data
+              notebook_task:
+                notebook_path: ../src/lakefed_ingest/copy_data_partitioned.ipynb
+                base_parameters:
+                  partition_id: "{{input.id}}"
+                source: WORKSPACE
+                warehouse_id: ${var.warehouse_id}
+              max_retries: 2
+              min_retry_interval_millis: 0
+              description: Copies data based on provided parameters
+          description: Iterates id_list set in get_partitions task
+      tags:
+        business_unit: ""
+        project: lakefed_ingest
+      queue:
+        enabled: false
+      parameters:
+        - name: batch_id
+          default: ""
+        - name: tgt_catalog
+          default: ""
+        - name: tgt_schema
+          default: ""
+        - name: tgt_table
+          default: ""
+        - name: src_catalog
+          default: ""
+        - name: src_schema
+          default: ""
+        - name: src_table
+          default: ""

--- a/src/lakefed_ingest/generate_partitions.ipynb
+++ b/src/lakefed_ingest/generate_partitions.ipynb
@@ -151,7 +151,7 @@
     "partitions_tbl = f'{tgt_catalog}.{tgt_schema}.{tgt_table}_partitions'\n",
     "\n",
     "# Write partitions to table\n",
-    "partition_df = get_partition_df(partition_list, num_partitions)\n",
+    "partition_df = get_partition_df(partition_list, num_partitions, 1000)\n",
     "partition_df.write.option(\"overwriteSchema\", \"true\").mode(\"overwrite\").saveAsTable(partitions_tbl)"
    ]
   },

--- a/src/lakefed_ingest/generate_partitions.ipynb
+++ b/src/lakefed_ingest/generate_partitions.ipynb
@@ -185,26 +185,31 @@
     "application/vnd.databricks.v1+cell": {
      "cellMetadata": {},
      "inputWidgets": {},
-     "nuid": "8aad25ce-35d6-4a1d-8366-1578bc1097b6",
+     "nuid": "8161587c-6966-4f3a-9689-5373f9f3bd2f",
      "showTitle": true,
      "tableResultSettingsMap": {},
-     "title": "Get List of Partitions"
+     "title": "Get List of Batches"
     }
    },
    "outputs": [],
    "source": [
     "# Get list of ids\n",
-    "id_list_qry = f\"\"\"\\\n",
-    "    select array_agg(id) as ids\n",
+    "partitions_qry = f\"\"\"\\\n",
+    "    select\n",
+    "      sort_array(array_agg(distinct batch_id)) as batch_ids,\n",
+    "      count(where_clause) as cnt_partitions\n",
     "    from {partitions_tbl}\n",
     "\"\"\"\n",
     "\n",
-    "id_list = spark.sql(id_list_qry).collect()[0][0]\n",
-    "id_list.sort()\n",
-    "print(f'Count of ids: {len(id_list)}')\n",
+    "partitions_df = spark.sql(partitions_qry)\n",
+    "batch_id_list = partitions_df.collect()[0]['batch_ids']\n",
+    "cnt_partitions = partitions_df.collect()[0]['cnt_partitions']\n",
+    "\n",
+    "print(f'Count of batches: {len(batch_id_list)}')\n",
+    "print(f'Count of partitions: {cnt_partitions}')\n",
     "\n",
     "# Assign id list to job task value to make it available to a for each task.\n",
-    "dbutils.jobs.taskValues.set(key=\"id_list\", value=id_list)"
+    "dbutils.jobs.taskValues.set(key=\"batch_id_list\", value=batch_id_list)"
    ]
   }
  ],
@@ -224,7 +229,7 @@
     },
     "pythonIndentUnit": 4
    },
-   "notebookName": "get_partitions",
+   "notebookName": "generate_partitions",
    "widgets": {}
   },
   "kernelspec": {

--- a/src/lakefed_ingest/generate_partitions.ipynb
+++ b/src/lakefed_ingest/generate_partitions.ipynb
@@ -5,7 +5,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "45ab3641-09f0-476e-9c1b-1e69957ee78c",
      "showTitle": false,
@@ -16,41 +19,6 @@
    "outputs": [],
    "source": [
     "from lakefed_ingest.main import *"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 0,
-   "metadata": {
-    "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {
-      "byteLimit": 2048000,
-      "rowLimit": 10000
-     },
-     "inputWidgets": {},
-     "nuid": "576410b5-873a-42ef-b3c2-7887dcf36cba",
-     "showTitle": false,
-     "tableResultSettingsMap": {},
-     "title": ""
-    }
-   },
-   "outputs": [],
-   "source": [
-    "dbutils.widgets.dropdown(\n",
-    "    \"src_type\",\n",
-    "    \"sqlserver\",\n",
-    "    [\"sqlserver\", \"oracle\", \"postgresql\", \"redshift\", \"synapse\", \"delta\"],\n",
-    "    \"01 Source Type\",\n",
-    ")\n",
-    "dbutils.widgets.text(\"src_catalog\", \"\", \"02 Source Catalog\")\n",
-    "dbutils.widgets.text(\"src_schema\", \"\", \"03 Source Schema\")\n",
-    "dbutils.widgets.text(\"src_table\", \"\", \"04 Source Table\")\n",
-    "dbutils.widgets.text(\"root_dir\", \"\", \"05 Root directory for project files\")\n",
-    "dbutils.widgets.text(\"partition_col\", \"\", \"08 Source Partition Column\")\n",
-    "dbutils.widgets.text(\"partition_size_mb\", \"\", \"09 Partition Size MB\")\n",
-    "dbutils.widgets.text(\"tgt_catalog\", \"\", \"10 Target Catalog\")\n",
-    "dbutils.widgets.text(\"tgt_schema\", \"\", \"11 Target Schema\")\n",
-    "dbutils.widgets.text(\"tgt_table\", \"\", \"12 Target Table\")"
    ]
   },
   {
@@ -87,7 +55,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ad06769d-e2a5-4474-a3ab-e2c335539074",
      "showTitle": true,
@@ -107,7 +78,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "3fb7659b-e5da-4300-8b95-79de9654d39d",
      "showTitle": true,
@@ -128,7 +102,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "ca88b99e-bed5-4f9b-a158-769d0627d2ca",
      "showTitle": true,
@@ -183,7 +160,10 @@
    "execution_count": 0,
    "metadata": {
     "application/vnd.databricks.v1+cell": {
-     "cellMetadata": {},
+     "cellMetadata": {
+      "byteLimit": 2048000,
+      "rowLimit": 10000
+     },
      "inputWidgets": {},
      "nuid": "8161587c-6966-4f3a-9689-5373f9f3bd2f",
      "showTitle": true,
@@ -230,7 +210,258 @@
     "pythonIndentUnit": 4
    },
    "notebookName": "generate_partitions",
-   "widgets": {}
+   "widgets": {
+    "partition_col": {
+     "currentValue": "ss_item_sk",
+     "nuid": "6ade68b1-9b6e-4f24-8424-00fe1fe56e6f",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "partition_col",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "partition_col",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "partition_size_mb": {
+     "currentValue": "128",
+     "nuid": "59d185c2-9a7d-4cc6-81ec-0d8f11419a25",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "partition_size_mb",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "partition_size_mb",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "src_catalog": {
+     "currentValue": "tpcds",
+     "nuid": "43162f1f-e929-4cc0-a409-1d3cee631306",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "src_catalog",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "src_catalog",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "src_schema": {
+     "currentValue": "sf_1000_liquid",
+     "nuid": "a6899bbd-325f-489c-bb0d-595842d6dd68",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "src_schema",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "src_schema",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "src_table": {
+     "currentValue": "store_sales",
+     "nuid": "ef4840b7-0a26-4b5f-ae8a-2aae7ed09a0d",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "src_table",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "src_table",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "src_type": {
+     "currentValue": "delta",
+     "nuid": "0f478c51-6683-407b-ba81-8eedd2e807b5",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "delta",
+      "label": "",
+      "name": "src_type",
+      "options": {
+       "widgetDisplayType": "Dropdown",
+       "choices": [
+        "sqlserver",
+        "oracle",
+        "postgresql",
+        "redshift",
+        "synapse",
+        "delta"
+       ],
+       "fixedDomain": true,
+       "multiselect": false
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "dropdown",
+      "defaultValue": "delta",
+      "label": "",
+      "name": "src_type",
+      "options": {
+       "widgetType": "dropdown",
+       "autoCreated": false,
+       "choices": [
+        "sqlserver",
+        "oracle",
+        "postgresql",
+        "redshift",
+        "synapse",
+        "delta"
+       ]
+      }
+     }
+    },
+    "tgt_catalog": {
+     "currentValue": "lakefed_ingest",
+     "nuid": "f2fc59b6-5723-44f4-b503-a03823c79e6b",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_catalog",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_catalog",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "tgt_schema": {
+     "currentValue": "tpcds_sf1000",
+     "nuid": "69027b7a-2e25-4543-b726-5c63c39bb6c3",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_schema",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_schema",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    },
+    "tgt_table": {
+     "currentValue": "store_sales",
+     "nuid": "30388bb3-2f28-453b-b20e-dbaa25976f5f",
+     "typedWidgetInfo": {
+      "autoCreated": false,
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_table",
+      "options": {
+       "widgetDisplayType": "Text",
+       "validationRegex": null
+      },
+      "parameterDataType": "String"
+     },
+     "widgetInfo": {
+      "widgetType": "text",
+      "defaultValue": "",
+      "label": "",
+      "name": "tgt_table",
+      "options": {
+       "widgetType": "text",
+       "autoCreated": false,
+       "validationRegex": null
+      }
+     }
+    }
+   }
   },
   "kernelspec": {
    "display_name": ".venv",

--- a/src/lakefed_ingest/get_partition_ids.sql
+++ b/src/lakefed_ingest/get_partition_ids.sql
@@ -1,0 +1,4 @@
+-- Get partitions ids for specified batch
+select id
+from identifier(:tgt_catalog || '.' || :tgt_schema || '.' || :tgt_table || '_partitions')
+where batch_id = :batch_id

--- a/src/lakefed_ingest/main.py
+++ b/src/lakefed_ingest/main.py
@@ -505,20 +505,19 @@ def get_partition_list(partition_col:str, lower_bound, upper_bound, num_partitio
         
     return partition_list
 
-def get_partition_df(partition_list:list[dict], num_partitions:int, batch_size:int = 500) -> DataFrame:
+def get_partition_df(partition_list:list[dict], num_partitions:int, batch_size:int = 1000) -> DataFrame:
     """Create dataframe from list of partitions
 
     Partitions are defined by a where clause that selects a range of data.
     A batch_id is assigned to each partition. This provides a way of
     dividing the full partition table into N size batches.
     
-    Batching is used to avoid exceeding the 48 KiB limit of taskValues.
-    https://docs.databricks.com/en/jobs/share-task-context.html
+    Batching is used to avoid exceeding the 1000 item limit of the for each task.
     
     Args:
         partition_list (list[dict]): List of dictionaries containing partition ranges
         num_partitions (int): Number of partitions is used to determing the number of batches
-        batch_size (int): Batch size. Defaults to 500.
+        batch_size (int): Batch size. Defaults to 1000.
     """
     
     # Calculate number of batches and round up


### PR DESCRIPTION
Implements a batching mechanism so that more than 1000 partitions (Queries) can be used with the partitioned copy jobs. This provides greater flexibility for large tables, by enabling a larger number of smaller queries.

lakefed_ingest_copy_partitioned is divided into a parent/child set of jobs.
- The parent job iterates batches
- Each child job iterates tasks within each batch
- Batches are iterated sequentially. Partitions are iterated at the specified concurrency.